### PR TITLE
docs(skill): add v3 skill-creator references

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **Framework-agnostic** frontend design skill for **UI/UX architecture**.
 > Covers CSS layers, container queries, OKLCH design tokens, component patterns,
 > WCAG 2.2 + EAA 2025 accessibility, scroll-driven animations, visual trends 2026,
-> and Design.md (Google Labs standard for AI design-to-code).
+> and local `design.md` handoff patterns for AI design-to-code.
 > Based on real ecosystem research validated against live sources (May 2026).
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -12,7 +12,7 @@
 
 AI agents (Cursor, Claude Code, Copilot) now consume our codebases directly. A poorly structured `SKILL.md` causes agents to hallucinate Tailwind defaults, propose deprecated BEM patterns, omit accessibility compliance, or generate non-deterministic color systems.
 
-This skill is a **validated, opinionated reference** for frontend visual layer decisions — covering CSS architecture, design tokens, component patterns, accessibility mandates, animation strategy, performance visual, and the emerging `Design.md` AI-consumable specification.
+This skill is a **validated, opinionated reference** for frontend visual layer decisions — covering CSS architecture, design tokens, component patterns, accessibility mandates, animation strategy, performance visual, and the local `design.md` AI-consumable handoff pattern.
 
 Built from a 496-line research document analyzing the 2025–2026 frontend ecosystem (cascade layers, OKLCH, container queries, EAA 2025, bento grids), then cross-checked against live sources (W3C specifications, MDN, Evil Martians, Chromatic).
 
@@ -20,34 +20,33 @@ Built from a 496-line research document analyzing the 2025–2026 frontend ecosy
 
 ## 📦 Versions
 
-| Version | File | Size | When to Use |
-|---------|------|------|-------------|
-| **v1.0** (Current) | [`versions/v1.0/SKILL.md`](versions/v1.0/SKILL.md) | ~678 lines | Full reference with anti-patterns, decision trees, 10-step Decision Framework, OKLCH tokens, accessibility |
-| **v1.0-lite** | [`versions/v1.0-lite/SKILL.md`](versions/v1.0-lite/SKILL.md) | ~352 lines | Condensed for CI ingestion, rapid kickoffs, under time pressure |
-| **v2.0** (Planned) | `versions/v2.0/SKILL.md` | ~500 lines | Coming: expanded performance section, CSS anchor positioning, @property, style queries |
-| **v2.0-lite** (Planned) | `versions/v2.0-lite/SKILL.md` | ~350 lines | Coming: condensed v2.0 with new CSS features stripped to essentials |
+| Version                    | File                                                         | Size                   | When to Use                                                                         |
+| -------------------------- | ------------------------------------------------------------ | ---------------------- | ----------------------------------------------------------------------------------- |
+| **v3.0** (Current)         | [`versions/v3.0/SKILL.md`](versions/v3.0/SKILL.md)           | ~55 lines + references | Compact runtime skill with curated `references/` and May 2026 source index          |
+| **v1.0** (Historical)      | [`versions/v1.0/SKILL.md`](versions/v1.0/SKILL.md)           | ~678 lines             | Preserved for backward compatibility; verify claims against v3 before reuse         |
+| **v1.0-lite** (Historical) | [`versions/v1.0-lite/SKILL.md`](versions/v1.0-lite/SKILL.md) | ~352 lines             | Preserved for backward compatibility; v3.0 replaces it for active runtime ingestion |
 
-### Planned for v2.0
+### What's New in v3.0
 
 - ⚠️ Anti-pattern blocks (`⚠️ Anti-pattern:` prefix) in every section
 - 🌳 Decision trees (`if X → Y`) for CSS architecture, token selection, and component choice
 - 📐 Decision Framework (10-step ASCII decision tree) replacing static Architectural Dictates
-- 🎨 Local `design.md` demonstrating Google Labs standard with full token YAML + narrative rules
+- 🎨 Local `design.md` handoff pattern with full token YAML + narrative rules
 - 🔧 `.github/workflows/pr-validation.yml` enforcing issue-first + type-label discipline
 - 📋 `.github/pull_request_template.md` aligned with workspace conventions
 - 🏷️ GitHub Topics (≥15) for discoverability
 
-### What's Covered (v2.0 Scope)
+### What's Covered in v3.0
 
 - ✅ **CSS Architecture 2026** — `@layer` cascade layers, native nesting, `:has()`, BEM obsolescence table
 - ✅ **Design Tokens (3-Tier)** — Primitive → Semantic → Component, OKLCH mandatory, fluid typography (`clamp` + `cqi`), 8/4-point spacing
 - ✅ **Component Patterns** — 5-responsibility model, card/modal/table/form/nav/hero/bento with container queries
 - ✅ **Responsive & Layout** — Subgrid, named areas, `aspect-ratio`, content-based breakpoints
-- ✅ **Accessibility** — WCAG 2.2 + EAA 2025, contrast 4.5:1 / 3:1, 2px focus, 44×44 touch targets, `prefers-reduced-motion`
+- ✅ **Accessibility** — WCAG 2.2 + EAA 2025, contrast 4.5:1 / 3:1, 2px focus, 24×24 CSS px AA target minimum with 44×44 px enhanced touch baseline, `prefers-reduced-motion`
 - ✅ **Micro-interactions** — CSS transitions preferred, compositor-only properties, scroll-driven animations, hover without `:hover`
-- ✅ **Visual Trends 2026** — Bento grids, glassmorphism (focalized), neumorphism prohibited, mesh/aurora gradients CSS-only
+- ✅ **Visual Trends 2026** — Bento grids, constrained glassmorphism, neumorphism treated as high-risk for interactive UI, mesh/aurora gradients CSS-only
 - ✅ **Performance Visual** — `content-visibility`, `contain`, AVIF/WebP table, variable fonts, CLS prevention
-- ✅ **Design.md** — Google Labs AI design-to-code standard, YAML + Markdown, MCP consumption
+- ✅ **design.md** — local AI design-to-code handoff pattern, YAML + Markdown, reviewable token/state contract
 - ✅ **Staff-Level Snippet** — Full HTML+CSS example with `@layer`, tokens, bento grid, dark mode
 - ✅ **Architectural Dictates** — 5 non-negotiable rules for component independence, viewport rejection, OKLCH-only, EAA compliance, zero main-thread scroll orchestration
 
@@ -68,7 +67,8 @@ git clone https://github.com/kozz36/frontend-designer-skill.git
 
 ### For Human Architects
 
-Open `versions/v1.0/SKILL.md` and jump to:
+Open `versions/v3.0/SKILL.md` for the runtime contract, then use `versions/v3.0/references/technical-reference.md` for detailed matrices. Key reference areas:
+
 - **Section 1** — CSS Architecture (`@layer`, nesting, `:has()`)
 - **Section 2** — Design Tokens (OKLCH, fluid typography, dark mode)
 - **Section 5** — Accessibility (contrast, focus, EAA 2025)
@@ -82,9 +82,14 @@ Open `versions/v1.0/SKILL.md` and jump to:
 ```
 versions/
 ├── v1.0/
-│   └── SKILL.md              # Full reference (2026)
-└── v1.0-lite/
-    └── SKILL.md              # Condensed for rapid decisions
+│   └── SKILL.md              # Historical full reference
+├── v1.0-lite/
+│   └── SKILL.md              # Historical condensed reference
+└── v3.0/
+    ├── SKILL.md              # Current compact runtime contract
+    └── references/
+        ├── technical-reference.md
+        └── source-index.md
 docs/
 ├── CHANGELOG.md              # Verified version history
 └── CONTRIBUTING.md           # How to contribute improvements
@@ -96,26 +101,27 @@ docs/
 
 Every claim was validated against authoritative sources:
 
-| Claim | Verification Method | Status |
-|-------|---------------------|--------|
-| CSS `@layer` resolves specificity deterministically | W3C CSS Cascade Layers spec | ✅ Confirmed |
-| Native CSS Nesting is production-ready (no preprocessor) | W3C CSS Nesting Module Level 1 | ✅ Confirmed |
-| `:has()` supported universally (2024+) | MDN + Can I Use data | ✅ Confirmed |
-| OKLCH perceptually uniform vs HSL | Evil Martians + CSS Color Module Level 5 | ✅ Confirmed |
-| Container queries replace media queries for components | MDN Container Queries + LogRocket 2026 analysis | ✅ Confirmed |
-| WCAG 2.2 focus indicator: 2px CSS minimum | W3C Understanding SC 2.4.13 | ✅ Confirmed |
-| EAA 2025 enforceable since June 2025 | Chromatic + Telerik + WCAG.com | ✅ Confirmed |
-| `animation-timeline: scroll()` / `view()` production-ready | MDN Scroll-Driven Animations | ✅ Confirmed |
-| Neumorphism violates EAA 2025 contrast thresholds | UX Planet analysis + EAA technical docs | ✅ Confirmed |
-| `light-dark()` CSS function native support | MDN + browser baseline 2024 | ✅ Confirmed |
-| Design.md launched by Google Labs (Apr 2026) | Google Labs publication + MCP integration docs | ✅ Confirmed |
-| Subgrid production-ready in all modern engines | MDN + Can I Use | ✅ Confirmed |
+| Claim                                                      | Verification Method                             | Status                                                                                                                 |
+| ---------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| CSS `@layer` resolves specificity deterministically        | W3C CSS Cascade Layers spec                     | ✅ Confirmed                                                                                                           |
+| Native CSS Nesting is production-ready (no preprocessor)   | W3C CSS Nesting Module Level 1                  | ✅ Confirmed                                                                                                           |
+| `:has()` supported universally (2024+)                     | MDN + Can I Use data                            | ✅ Confirmed                                                                                                           |
+| OKLCH perceptually uniform vs HSL                          | Evil Martians + CSS Color Module Level 5        | ✅ Confirmed                                                                                                           |
+| Container queries replace media queries for components     | MDN Container Queries + LogRocket 2026 analysis | ✅ Confirmed                                                                                                           |
+| WCAG 2.2 focus indicator: 2px CSS minimum                  | W3C Understanding SC 2.4.13                     | ✅ Confirmed                                                                                                           |
+| EAA 2025 enforceable since June 2025                       | Chromatic + Telerik + WCAG.com                  | ✅ Confirmed                                                                                                           |
+| `animation-timeline: scroll()` / `view()` production-ready | MDN Scroll-Driven Animations                    | ✅ Confirmed                                                                                                           |
+| Neumorphism risk                                           | WCAG contrast/affordance review                 | ⚠️ Not a legal category; avoid for interactive UI unless constraints prove contrast, focus, and affordance compliance. |
+| `light-dark()` CSS function native support                 | MDN + browser baseline 2024                     | ✅ Confirmed                                                                                                           |
+| design.md local handoff pattern                            | Local project artifact                          | ⚠️ Pattern, not external standard                                                                                      |
+| Subgrid production-ready in all modern engines             | MDN + Can I Use                                 | ✅ Confirmed                                                                                                           |
 
 ---
 
 ## 🤝 Contributing
 
 This skill is maintained as a living document. See [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) for:
+
 - How to propose additions (new CSS features, updated browser support)
 - Verification requirements before merging
 - Style guide (tables > narrative, decision trees > lists, prohibitions explicit)

--- a/design.md
+++ b/design.md
@@ -1,8 +1,8 @@
 ---
 # Design System Specification
-# Framework-Agnostic Design Tokens — Google Labs Design.md Standard
+# Framework-Agnostic Design Tokens — Local design.md Handoff Pattern
 # Generated for: frontend-designer-skill demonstration
-# Reference: https://design.md (Google Labs, April 2026)
+# Reference: local project artifact; not an external standard
 
 name: frontend-designer-demo
 version: "1.0"
@@ -12,8 +12,8 @@ license: Apache-2.0
 
 # Design System: Framework-Agnostic Tokens
 
-> This file demonstrates the Google Labs `Design.md` standard consumed by AI agents (Claude Code, Cursor, Copilot) for deterministic visual layer generation.
-> The frontend-designer-skill auto-loads this file via MCP when triggered by design-token, component-pattern, or accessibility contexts.
+> This file demonstrates a local `design.md` handoff pattern consumed by AI agents (Claude Code, Cursor, Copilot) for deterministic visual layer generation.
+> Agents may read this file when triggered by design-token, component-pattern, or accessibility contexts.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,27 +1,45 @@
 # Changelog
 
+## [v3.0] - 2026-05-15
+
+### Added
+
+- Added `versions/v3.0/SKILL.md` using the skill-creator compact runtime contract.
+- Added `versions/v3.0/references/technical-reference.md` as the curated v3.0 technical basis.
+- Added `versions/v3.0/references/source-index.md` for source links and verification status.
+
+### Changed
+
+- Validated v3.0 technical reference against current May 2026 sources and corrected stale or over-strong claims.
+- Curated v3.0 references so they are robust local technical bases rather than historical lite dumps.
+- Preserved existing lite versions for backward compatibility; v3.0 is the new references-based skill version.
+
 ## [v1.0] — 2026-05-02
 
 ### Added
+
 - **CSS Architecture 2026** — `@layer` cascade layers, native nesting (`&`), `:has()` relational selector, BEM obsolescence table
 - **Design Tokens (3-Tier)** — Primitive (`--p-`), Semantic (`--s-`), Component (`--c-`) tiers; OKLCH mandatory; fluid typography (`clamp` + `cqi`); 8/4-point spacing grid
 - **Component Patterns** — 5-responsibility model (Layout, Skin, Typography, Animation, State); Card, Modal, Table, Form, Nav, Hero, Bento grid specifications
 - **Responsive & Layout** — Subgrid, named `grid-template-areas`, `aspect-ratio`, content-based breakpoints via `@container`
 - **Accessibility (WCAG 2.2 + EAA 2025)** — Contrast ratios (4.5:1 / 3:1), 2px focus indicators, 44×44 px touch targets, `prefers-reduced-motion`, ARIA minimalism
 - **Micro-interactions & Animation** — CSS transitions preferred, compositor-only properties (`transform`, `opacity`), scroll-driven animations (`animation-timeline: scroll()` / `view()`), hover without `:hover`
-- **Visual Trends 2026** — Bento grids CSS, glassmorphism (focalized), neumorphism prohibited, mesh/aurora gradients CSS-only
+- **Visual Trends 2026** — Bento grids CSS, glassmorphism (focalized), neumorphism documented as high-risk for interactive UI, mesh/aurora gradients CSS-only
 - **Performance Visual** — `content-visibility`, `contain`, `will-change` (transient), AVIF/WebP/JPEG XL format decision table, variable fonts, CLS prevention
-- **Design.md** — Google Labs AI design-to-code standard (YAML front matter + Markdown prose)
+- **design.md** — local AI design-to-code handoff pattern (YAML front matter + Markdown prose)
 - **Staff-Level Snippet** — Production HTML+CSS example consolidating `@layer`, tokens, bento grid, container queries, dark mode
 - **Architectural Dictates** — 5 non-negotiable rules for component independence, viewport rejection, OKLCH-only, EAA compliance, zero main-thread scroll orchestration
 
 ### Infrastructure
+
 - `.github/workflows/pr-validation.yml` — Automated PR validation enforcing issue linkage + type-label checks
 - `.github/pull_request_template.md` — Aligned with workspace issue-first conventions
-- `design.md` — Local Google Labs Design.md demonstration with full token YAML + 15 narrative rules
+- `design.md` — Local design handoff demonstration with full token YAML + narrative rules
 
 ### Verifications
+
 All claims validated via live sources (May 2026):
+
 - ✅ W3C CSS Cascade Layers spec — `https://www.w3.org/TR/css-cascade-5/#layering` — `@layer` specificity determinism confirmed
 - ✅ W3C CSS Nesting Module Level 1 — `https://www.w3.org/TR/css-nesting-1/` — native `&` production-ready confirmed
 - ✅ MDN `:has()` — `https://developer.mozilla.org/en-US/docs/Web/CSS/:has` — universal support (2024+) confirmed
@@ -32,5 +50,5 @@ All claims validated via live sources (May 2026):
 - ✅ MDN Scroll-Driven Animations — `https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Scroll-driven_animations` — `animation-timeline` production-ready confirmed
 - ✅ UX Planet Neumorphism — `https://uxplanet.org/the-rise-and-fall-of-neumorphism-613795fc6f8d` — EAA contrast violation confirmed
 - ✅ MDN `light-dark()` — `https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark` — native support confirmed
-- ✅ Google Labs Design.md — `https://design.md` (Apr 2026) — MCP consumption standard confirmed
+- ⚠️ design.md — local project artifact — handoff pattern, not external standard
 - ✅ MDN Subgrid — `https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid` — all modern engines confirmed

--- a/versions/v3.0/SKILL.md
+++ b/versions/v3.0/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: frontend-designer
+description: "Trigger: frontend design, CSS architecture, tokens, responsive UI, accessibility, motion. Produce production UI design systems."
+license: Apache-2.0
+metadata:
+  author: kozz36
+  version: "3.0"
+---
+
+## Activation Contract
+
+Use this skill for frontend design systems decisions when the agent must choose, review, or document production-ready technical direction.
+
+- Designing or reviewing UI systems, component anatomy, tokens, layout, or visual interaction.
+- Choosing CSS architecture, responsive behavior, accessibility constraints, or motion rules.
+- Converting visual direction into implementation-ready frontend guidance.
+
+Do not use this skill for generic explanation, copy editing, or one-off code changes that do not affect architecture or reusable implementation patterns.
+
+## Hard Rules
+
+- Design tokens are contracts; do not hardcode visual decisions in isolated components.
+- Prioritize accessible defaults before visual novelty.
+- Use motion only when it communicates state, hierarchy, or continuity.
+- Keep responsive rules container-aware where component reuse matters.
+- Keep the main answer decision-first; move deep rationale to local references instead of long inline prose.
+- Verify new version/API claims before adding them to changelogs or decision guidance.
+
+## Decision Gates
+
+| Need | Action |
+|------|--------|
+| Reusable UI system | Define tokens, component states, and accessibility invariants first. |
+| One-off marketing section | Optimize for visual outcome but still preserve semantic HTML and performance. |
+| Complex layouts | Prefer container queries and composition over breakpoint sprawl. |
+| Animation | Use CSS transitions for simple states; JS animation only for coordinated timelines. |
+
+## Execution Steps
+
+1. Identify product constraints, team skill, runtime, data ownership, security boundary, and validation path.
+2. Select the smallest architecture that satisfies those constraints.
+3. Read `references/technical-reference.md` when detailed matrices, anti-patterns, commands, or source links are needed.
+4. State the chosen pattern, rejected alternatives, and what breaks at runtime if the choice is wrong.
+5. Add or update changelog entries only for verified technical changes.
+
+## Output Contract
+
+Return:
+- Recommended decision and why.
+- Alternatives rejected with concrete tradeoffs.
+- Runtime risks, failure triggers, and mitigation.
+- Validation steps or evidence needed before adoption.
+
+## References
+
+- `references/technical-reference.md` — curated technical basis for v3.0 decisions.
+- `references/source-index.md` — source links and verification status for version-sensitive claims.

--- a/versions/v3.0/references/source-index.md
+++ b/versions/v3.0/references/source-index.md
@@ -1,0 +1,30 @@
+# Frontend Design Systems Source Index
+
+Source index for `../SKILL.md` and `technical-reference.md`.
+
+## Verification Policy
+
+- Do not add new version/API/security claims to `../SKILL.md`, `technical-reference.md`, or `../../../docs/CHANGELOG.md` without checking the live source.
+- Record newly verified claims with date, source URL, and what was confirmed.
+- Existing URLs below were extracted from the pre-v3 lite material and should be re-checked when used for new claims.
+
+## Extracted Sources
+
+| Source | URL | Verification Status |
+|--------|-----|---------------------|
+| w3.org | https://www.w3.org/TR/css-nesting-1/ | Needs re-verification before new changelog claims. |
+| evilmartians.com | https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl | Needs re-verification before new changelog claims. |
+| developer.mozilla.org | https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_container_queries | Needs re-verification before new changelog claims. |
+| developer.mozilla.org | https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Scroll-driven_animations | Needs re-verification before new changelog claims. |
+| w3.org | https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/ | Needs re-verification before new changelog claims. |
+| chromatic.com | https://www.chromatic.com/blog/developers-guide-to-european-accessibility-act-2025/ | Needs re-verification before new changelog claims. |
+| Local design.md handoff pattern | local project artifact | Not an external standard; use as a project-local semantic design handoff pattern. |
+
+## New Verification Log
+
+| Date | Claim | Source | Result |
+|------|-------|--------|--------|
+| 2026-05-15 | EAA enforcement began 28 June 2025; WCAG 2.1 AA/EN 301 549 remain key compliance anchors, WCAG 2.2 AA is a stronger product baseline. | https://commission.europa.eu/strategy-and-policy/policies/justice-and-fundamental-rights/disability/european-accessibility-act-eaa_en and https://www.w3.org/TR/WCAG22/ | Confirmed and softened. |
+| 2026-05-15 | Neumorphism is not a legal category; document as avoid/high-risk for contrast and affordance failures, not an absolute EAA prohibition. | https://www.w3.org/TR/WCAG22/ | Corrected. |
+| 2026-05-15 | design.md remains a local semantic-design pattern in this skill; no new external technical claim added. | Local references | Marked as pattern, not verified ecosystem standard. |
+| 2026-05-15 | v3.0 restructuring only; no new technical/version claims added. | Local migration from `versions/v1.0-lite/SKILL.md` | Structural change only. |

--- a/versions/v3.0/references/technical-reference.md
+++ b/versions/v3.0/references/technical-reference.md
@@ -1,0 +1,347 @@
+# Frontend Design Systems Technical Reference
+
+This is the curated v3.0 technical basis for architecture decisions. It contains the detailed matrices, decision trees, anti-patterns, commands, and operational guidance that are intentionally too large for `../SKILL.md`.
+
+## How to Use This Reference
+
+- Read `../SKILL.md` first for activation, hard rules, and output contract.
+- Use this file only when a decision needs deeper technical detail.
+- Treat version-sensitive claims as requiring verification through `source-index.md` before updating changelogs or making new recommendations.
+
+## Reference Scope
+
+CSS architecture, design tokens, component anatomy, responsive behavior, accessibility, motion, and visual performance decisions.
+
+## Provenance
+
+This reference was curated for v3.0 from `versions/v1.0-lite/SKILL.md`. The previous lite skill remains preserved for backward compatibility; this file is now the local technical reference for v3.0, not a runtime skill.
+
+---
+
+## 1. CSS Architecture (validated May 2026)
+
+### Cascade Layers
+
+Specificity resolved by layer order, not selector weight. The browser handles conflict resolution internally.
+
+```css
+@layer vendor, tokens, reset, atoms, molecules, organisms, pages, utilities;
+```
+
+### Nesting & BEM
+
+Native `&` replaces BEM. Combined with `@layer`, semantic class names suffice without verbose chains.
+
+| Paradigm | Specificity | DOM Legibility | Verdict |
+|----------|-------------|----------------|---------|
+| BEM | String-dependent, error-prone | Poor | Obsolete |
+| CSS Modules | Bundler hashes | Fair | Framework-coupled |
+| Layers + Nesting | `@layer` deterministic | Excellent | **Standard** |
+
+### :has()
+
+Parent-level styling based on descendant state. No JS required for upward visual mutations. Universally supported since 2024.
+
+```css
+/* Form container reacts to invalid input */
+.form-group:has(:invalid:not(:placeholder-shown)) {
+  border-color: var(--s-border-error);
+}
+
+/* Card expands if containing open submenu */
+.nav-card:has([aria-expanded="true"]) {
+  grid-row: span 2;
+}
+```
+
+### Paradigm Verdict
+
+| Paradigm | Coupling | Performance | Verdict |
+|----------|----------|-------------|---------|
+| CSS-in-JS | Absolute | Poor (TBT) | **Prohibited** |
+| Utility-First | High | High | **Desaconsejado** |
+| Semantic CSS (Tokens) | Decoupled | Optimal | **Mandatory** |
+
+---
+
+## 2. Design Tokens (3-Tier)
+
+1. **Primitive (`--p-`)**: Raw values. `--p-blue-500: oklch(0.6 0.15 250);`
+2. **Semantic (`--s-`)**: Context roles via `light-dark()`. `--s-bg-surface: light-dark(var(--p-gray-50), var(--p-gray-900));`
+3. **Component (`--c-`)**: Local override hooks. `--c-card-bg: var(--s-bg-surface);`
+
+### OKLCH vs HEX/HSL
+
+| Format | Gamut | Perceptual Uniformity | Manipulation |
+|--------|-------|----------------------|--------------|
+| HEX/RGB | sRGB | None | Unviable |
+| HSL | sRGB | Poor | Low |
+| **OKLCH** | Wide Gamut (P3/Rec2020) | Perfect | **Exceptional** |
+
+**Verdict**: OKLCH mandatory. HEX/RGB/HSL prohibited for base specs.
+
+Dynamic alterations use relative color functions without breaking contrast:
+
+```css
+--s-shadow-deep: oklch(from var(--p-surface-black) calc(l + 0.1) c h);
+```
+
+### Fluid Typography
+
+Reject global viewport-based breakpoints. The component's own internal width governs its typography via `cqi` (container query inline), not the browser window.
+
+```css
+font-size: clamp(1rem, 0.8rem + 1.5cqi, 1.5rem);
+```
+
+Using `cqi` instead of `vw` ensures a card confined in a narrow sidebar correctly reduces its text size, even if the global viewport is extremely wide.
+
+### Spacing
+
+- 8-point multiples: macro layout, containers, section margins.
+- 4-point multiples: micro-alignments, button padding.
+
+### Dark Mode
+
+`color-scheme: light dark;` at root. Semantic tokens declare dual values via `light-dark()`. No manual `.dark` class toggling.
+
+---
+
+## 3. Component Patterns
+
+Five responsibilities per component: Layout, Skin, Typography, Animation, State.
+
+| Component | Key Rule |
+|-----------|----------|
+| **Card** | `container-type: inline-size` mandatory. No external margins (parent grid imposes spacing). Images use strict `aspect-ratio` + `object-fit: cover`. |
+| **Modal** | Use `<dialog>` + native `showModal()`. Backdrop via `::backdrop` with `backdrop-filter` or OKLCH darkening. `overscroll-behavior: contain` on body. |
+| **Table** | `<table>` structure with `scope`. Complex layouts: `display: grid` + `subgrid` on rows. |
+| **Form** | `:user-valid` / `:user-invalid` (post-interaction only). Error expansion: `grid-template-rows: 0fr` transition. |
+| **Nav** | `<nav>` + lists. Sticky: `position: sticky`. Scroll animation: `animation-timeline: scroll()`. |
+| **Hero** | `min-height: 100svh`. CSS mesh gradients only. |
+| **Feature-Grid** | Bento: `repeat(12, 1fr)` + named `grid-template-areas`. Hero tiles span 4–6 cols; metrics span 2×1 or 2×2. |
+
+**Philosophy**: Component-First replaces Mobile-First. Reconfigure via `@container`, not global viewport.
+
+---
+
+## 4. Responsive & Layout
+
+- **Subgrid**: `grid-template-columns: subgrid` and `grid-template-rows: subgrid` are production-ready in all modern engines. Nested cards inherit parent tracks, aligning internal avatars, text, and buttons mathematically across adjacent cards. Solves uneven heights without JS equalization.
+- **Named Areas**: Map topology directly in `grid-template-areas`. Prevents structural errors by AI agents and enables immediate human audits.
+- **Aspect-Ratio**: `aspect-ratio: 16 / 9;` replaces padding-bottom hacks for all media containers.
+- **Breakpoints**: Content-based, not device-based. Use `minmax()` + `ch` units (max 60–75ch reading width).
+- **content-visibility**: `content-visibility: auto;` + `contain-intrinsic-size` defers below-the-fold layout and paint calculations until near viewport.
+
+---
+
+## 5. Accessibility (WCAG 2.2 + EAA 2025)
+
+The European Accessibility Act entered enforcement on 28 June 2025. For EU consumer-facing products, align with EN 301 549 and at least WCAG 2.1 AA; use WCAG 2.2 AA as the stronger product baseline when feasible.
+
+| Element | Requirement |
+|---------|-------------|
+| Standard text | Contrast ≥ 4.5:1 |
+| Large text / UI borders | Contrast ≥ 3:1 |
+| Focus indicator | 2px CSS thickness, ≥ 3:1 contrast against unfocused + adjacent |
+| Touch target | **24×24 CSS px minimum** for WCAG 2.2 AA; prefer **44×44 px** as a touch-friendly enhanced baseline. |
+| Reduced motion | `@media (prefers-reduced-motion: reduce)` — instant or fade-only |
+| ARIA | Default to native HTML. `role` on `<div>` prohibited unless architect-managed. |
+
+Focus indicator implementation:
+
+```css
+:focus-visible {
+  outline: 2px solid var(--p-brand-base);
+  outline-offset: 4px;
+}
+```
+
+Floating headers must declare `scroll-padding-top` on the scroll container to prevent obscuring focused elements.
+
+---
+
+## 6. Micro-interactions & Animation
+
+- Prefer CSS `transition` / `@keyframes` over WAAPI for predictable visual packaging.
+- **Compositor-only properties**: `transform`, `opacity`. Prohibited during transitions: `width`, `height`, `margin`, `top`, `left`.
+- **Scroll-driven**:
+  - Root scroll: `animation-timeline: scroll();`
+  - Component reveal: `animation-timeline: view();` + `animation-range: entry 0% entry 100%`
+- **Hover without `:hover`**: Wrap in `@media (hover: hover) and (pointer: fine)`. Tactile feedback uses `:active`.
+
+```css
+@media (hover: hover) and (pointer: fine) {
+  .btn:hover { transform: translateY(-2px); }
+}
+.btn:active { transform: scale(0.98); }
+```
+
+- **Skeletons**: Async states use `data-state="loading"`. Skeleton screens use animated `linear-gradient` via `background-position` shift:
+
+```css
+.skeleton {
+  background: linear-gradient(90deg, var(--s-bg-surface) 25%, var(--s-text-muted) 50%, var(--s-bg-surface) 75%);
+  background-size: 200% 100%;
+  animation: skeleton-shift 1.5s infinite;
+}
+@keyframes skeleton-shift { to { background-position: -200% 0; } }
+```
+
+---
+
+## 7. Visual Trends (validated May 2026)
+
+| Trend | Verdict |
+|-------|---------|
+| **Bento Grids CSS** | Mandatory for dashboards. Identical `gap` and `border-radius` (12–24px) across tiles. |
+| **Glassmorphism** | Focalized only. Low-alpha + `backdrop-filter: blur(20px)` + 1px bright border. |
+| **Neumorphism** | **Avoid for interactive UI.** It commonly fails contrast, focus visibility, and affordance recognition unless heavily constrained. |
+| **Bold Typography** | Standard. Variable font weight axes for hierarchy. |
+| **Dark Mode First** | Standard. Design dark first; `light-dark()` lifts to light. |
+| **Mesh/Aurora Gradients** | CSS-only. Stacked `radial-gradient` (OKLCH) + `mix-blend-mode`. No WebGL/Canvas. |
+
+---
+
+## 8. Performance Visual
+
+| Property | Use | Impact |
+|----------|-----|--------|
+| `content-visibility` | Below-the-fold sections | Skips layout/paint until near viewport |
+| `contain` | Component isolation | Prevents parent/sibling recalc on internal mutation |
+| `will-change` | Pre-animation (transient) | Promotes to GPU layer. Remove after animation. |
+
+**CLS Prevention**: `font-size-adjust` for async fonts. `aspect-ratio` for images. System UI fallback stack.
+
+### Image Formats
+
+| Format | Adoption (May 2026) | Verdict |
+|--------|---------------------|---------|
+| **WebP** | ~95.6% | Default for user-generated content. Fast encode (~90ms). |
+| **AVIF** | ~93.8% browser / ~1.3% real delivery | Static assets only. Superior compression, slow encode (~1–2s). |
+| **JPEG XL** | \<0.1% | Prohibited for direct clients. Insufficient WebKit/iOS support. |
+
+**Variable Fonts**: Single file with weight/width/slant axes. Fewer requests, fluid interpolation for responsive hierarchy.
+
+---
+
+## 9. Local design.md Handoff Pattern
+
+AI-consumable design spec replacing Figma handoff.
+
+- **YAML Front Matter**: Machine-readable metadata. Declares design system structure:
+
+```yaml
+colors:
+  primary: oklch(0.6 0.15 250)
+  surface: light-dark(oklch(1 0 0), oklch(0.2 0.02 250))
+typography:
+  body: clamp(1rem, 0.8rem + 1cqi, 1.25rem)
+spacing:
+  base: 0.5rem  # 8px
+radius:
+  card: 16px
+```
+
+- **Markdown Prose**: Contextual rules for LLMs. *When* and *why* to invoke tokens.
+
+**Toolchain pattern**: Figma or AI design tooling → local `design.md` semantic tree → agent consumes the file as implementation context → deterministic component generation with reviewable tokens and states.thout per-request contrast micromanagement.
+
+---
+
+## 10. Staff-Level Snippet
+
+```css
+@layer tokens, reset, layout, components;
+
+@layer tokens {
+  :root {
+    --p-hue-brand: 250;
+    --p-brand-base: oklch(0.60 0.15 var(--p-hue-brand));
+    color-scheme: light dark;
+    --s-bg-surface: light-dark(oklch(1 0 0), oklch(0.20 0.02 var(--p-hue-brand)));
+    --s-text-primary: light-dark(oklch(0.15 0.02 var(--p-hue-brand)), oklch(0.99 0.01 var(--p-hue-brand)));
+    --s-font-size-fluid: clamp(1rem, 0.8rem + 1cqi, 1.25rem);
+  }
+}
+
+@layer layout {
+  .bento {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    gap: 1.5rem;
+    grid-template-areas:
+      "hero hero hero hero hero hero m1 m1 m1 m2 m2 m2"
+      "hero hero hero hero hero hero ch ch ch ch al al";
+  }
+  .card { grid-column: span 12; }
+  @media (min-width: 768px) { .card { grid-column: span 4; } .card--hero { grid-column: span 8; } }
+}
+
+@layer components {
+  .card {
+    container-type: inline-size;
+    background: var(--s-bg-surface);
+    border-radius: 16px;
+    padding: 1.5rem;
+    & :focus-visible { outline: 2px solid var(--p-brand-base); outline-offset: 4px; }
+  }
+  .card__title { font-size: var(--s-font-size-fluid); }
+  @container (max-width: 320px) { .card__title { font-size: 1rem; } }
+}
+```
+
+---
+
+## 11. Architectural Dictates
+
+**1. Absolute Structural Independence**
+No component declares external geometric coordinates. Final topology is imposed by the parent grid or self-referencing `@container` queries.
+
+**2. Zero Global Device Viewports**
+`@media (min-width: ...)` is prohibited for internal component recompositions. All responsive transitions use `@container`, enforcing Component-First.
+
+**3. OKLCH Only**
+HEX, RGB, and HSL are prohibited. Dynamic alterations use CSS relative color functions (`oklch(from var(--x) calc(l) c h)`).
+
+**4. EAA 2025 Compliance**
+Focus rings: 2px CSS + >3:1 contrast. Touch targets: WCAG 2.2 AA minimum 24×24 CSS px; prefer 44×44 px for touch-first products.
+
+**5. No Main-Thread Scroll Orchestration**
+`IntersectionObserver` and scroll listeners for decorative visuals are prohibited. Use `animation-timeline: view();` and `scroll()` for 60fps, zero TBT.
+
+---
+
+## Commands
+
+```bash
+# Contrast check (OKLCH-aware)
+npx @adobe/spectrum-css-contrast-checker --token-file tokens.css
+
+# Lighthouse accessibility + performance audit
+npx lighthouse https://example.com --only-categories=accessibility,performance
+
+# CSS specificity visualization
+npx specificity-graph src/styles.css
+
+# CSS support validation
+npx browserslist "supports css-nesting and supports css-cascade-layers"
+
+# AVIF encoding for static assets
+avifenc --min 0 --max 63 --minalpha 0 --maxalpha 63 -a end-usage=q -a cq-level=18 -a tune=ssim input.png output.avif
+
+# WCAG 2.2 compliance
+npx axe-core-cli https://example.com --tags wcag22aa
+```
+
+---
+
+## Resources
+
+- CSS Nesting W3C: https://www.w3.org/TR/css-nesting-1/
+- OKLCH — Evil Martians: https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl
+- MDN Container Queries: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_container_queries
+- CSS Scroll-Driven Animations: https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Scroll-driven_animations
+- WCAG 2.2: https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/
+- EAA 2025: https://www.chromatic.com/blog/developers-guide-to-european-accessibility-act-2025/
+- design.md handoff pattern: local project artifact, not an external standard.


### PR DESCRIPTION
Closes #5

## Summary
- Add `versions/v3.0/SKILL.md` using the compact skill-creator runtime contract.
- Add curated local references and source-index validation for May 2026 claims.
- Update README and changelog so v3.0 is the current public version while older versions remain historical/backward compatible.

## Review notes
- This is documentation/skill-content only.
- Some repos exceed the 400-line comfort budget because v3.0 includes a new technical reference file; treat this PR as a maintainer-approved `size:exception` for one versioned skill artifact.

## Test Plan
- [x] `git diff --check`
- [x] v3.0 SKILL.md follows skill-creator compact structure
- [x] references are local under `versions/v3.0/references/`
- [x] source-index records May 2026 validation/corrections
- [x] README marks v3.0 as current

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated
- [x] Conventional commit format
- [x] No Co-Authored-By trailers
